### PR TITLE
Bugfix static file path, fixes #15

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -26,7 +26,7 @@ module.exports = {
     port: 8080,
     autoOpenBrowser: true,
     assetsSubDirectory: 'static',
-    assetsPublicPath: '',
+    assetsPublicPath: '/',
     proxyTable: {},
     // CSS Sourcemaps off by default because relative paths are "buggy"
     // with this option, according to the CSS-Loader README


### PR DESCRIPTION
Static files were not available under /static/ when running in dev mode.