### PR TITLE
fix: gets rid of the No PostCss issue on initial install and run

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -25,7 +25,8 @@ exports.cssLoaders = function (options) {
   const postcssLoader = {
     loader: 'postcss-loader',
     options: {
-      sourceMap: options.sourceMap
+      sourceMap: options.sourceMap,
+      plugins: function() { return []; }
     }
   }
 


### PR DESCRIPTION
I downloaded the template for the first time today and ran into an issue after `npm install` and `npm start`.

I was getting the "No PostCss Config found in ..."

This will fix it!  Thanks!

